### PR TITLE
Add example link prediction visualization

### DIFF
--- a/draft/README.md
+++ b/draft/README.md
@@ -1,1 +1,13 @@
 Crawl data from https://books.toscrape.com
+
+## Link Prediction Visualization
+
+This repository also includes a simple script `visualize_link_prediction.py` that demonstrates link prediction on a toy graph.
+
+Run the script with:
+
+```
+python visualize_link_prediction.py
+```
+
+It creates a small sample graph, predicts additional links based on the number of common neighbors, and visualizes the original and augmented graphs side by side.

--- a/visualize_link_prediction.py
+++ b/visualize_link_prediction.py
@@ -1,0 +1,56 @@
+import networkx as nx
+import matplotlib.pyplot as plt
+
+
+def build_graph():
+    """Create a sample graph for demonstration."""
+    # simple undirected graph
+    G = nx.Graph()
+    edges = [(1, 2), (1, 3), (2, 3), (3, 4), (4, 5)]
+    G.add_edges_from(edges)
+    return G
+
+
+def predict_links(G, top_k=2):
+    """Predict links using common neighbors heuristic."""
+    scores = []
+    for u, v in nx.non_edges(G):
+        cn = len(list(nx.common_neighbors(G, u, v)))
+        if cn > 0:
+            scores.append(((u, v), cn))
+    scores.sort(key=lambda x: x[1], reverse=True)
+    return [edge for edge, _ in scores[:top_k]]
+
+
+def visualize(G, predicted_edges):
+    """Plot original graph and graph with predicted edges."""
+    pos = nx.spring_layout(G, seed=42)
+
+    plt.figure(figsize=(10, 5))
+
+    # original graph
+    plt.subplot(1, 2, 1)
+    nx.draw(G, pos, with_labels=True, node_color='lightblue', edge_color='gray')
+    plt.title('Original Graph')
+
+    # graph with predicted edges
+    G_pred = G.copy()
+    G_pred.add_edges_from(predicted_edges)
+
+    plt.subplot(1, 2, 2)
+    nx.draw(G_pred, pos, with_labels=True, node_color='lightblue', edge_color='gray')
+    nx.draw_networkx_edges(G_pred, pos, edgelist=predicted_edges, edge_color='red', style='dashed')
+    plt.title('With Predicted Links')
+
+    plt.tight_layout()
+    plt.show()
+
+
+def main():
+    G = build_graph()
+    predicted = predict_links(G)
+    visualize(G, predicted)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `visualize_link_prediction.py` demonstrating link prediction with NetworkX
- document how to run the script in the draft README

## Testing
- `python visualize_link_prediction.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685161b6f97883288bedab0f11ec0944